### PR TITLE
fix AABBs to draw in world space

### DIFF
--- a/addons/zylann.debug_draw/debug_draw.gd
+++ b/addons/zylann.debug_draw/debug_draw.gd
@@ -111,7 +111,7 @@ func draw_box_aabb(aabb: AABB, color = Color.WHITE, linger_frames = 0):
 	var mat := _get_line_material()
 	mat.albedo_color = color
 	mi.material_override = mat
-	mi.position = aabb.position
+	mi.position = aabb.get_center()
 	mi.scale = aabb.size
 	_boxes.append({
 		"node": mi,


### PR DESCRIPTION
AABBs were being drawn centered around their `.position`. However `position` represents one of the corners of the box, with `get_center()` returning the center. By switching the origin of the drawn box to the center point of the AABB, the drawing matches the AABB correctly.